### PR TITLE
Tutorial video deletion

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -30,6 +30,13 @@ class Admin::TutorialsController < Admin::BaseController
     redirect_to edit_admin_tutorial_path(tutorial)
   end
 
+  def destroy
+    tutorial = Tutorial.find(params[:id])
+    tutorial.destroy
+    flash[:notice] = "#{tutorial.title} has been deleted."
+    redirect_to admin_dashboard_path
+  end
+
   private
 
   def tutorial_params

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,5 @@
 class Tutorial < ApplicationRecord
-  has_many :videos, -> { order(position: :ASC) }
+  has_many :videos, -> { order(position: :ASC) }, dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 
@@ -7,5 +7,5 @@ class Tutorial < ApplicationRecord
   validates_presence_of :description
   validates_presence_of :thumbnail
 
-  scope :non_classroom_content, -> { where(classroom: false) } 
+  scope :non_classroom_content, -> { where(classroom: false) }
 end

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -11,11 +11,11 @@
     <th>Actions</th>
   </tr>
   <% @facade.tutorials.each do |tutorial| %>
-    <tr class="admin-tutorial-card">
+    <tr class="admin-tutorial-card-<%= tutorial.id %>">
       <td><%= link_to tutorial.title, tutorial_path(tutorial) %></td>
       <td>
-        <%= link_to "Edit", edit_admin_tutorial_path(tutorial) %> |
-        <%= link_to 'Destroy', tutorial_path(tutorial),
+        <%= button_to "Edit", edit_admin_tutorial_path(tutorial), method: :get %>
+        <%= button_to 'Destroy', admin_tutorial_path(tutorial),
                                method: :delete,
                                data: { confirm: 'Are you sure?' } %>
       </td>

--- a/spec/features/admin/admin_can_add_tags_to_tutorials_spec.rb
+++ b/spec/features/admin/admin_can_add_tags_to_tutorials_spec.rb
@@ -10,7 +10,7 @@ describe 'An admin user can add tags to tutorials' do
 
     visit '/admin/dashboard'
 
-    within(first('.admin-tutorial-card')) do
+    within(first(".admin-tutorial-card-#{tutorial.id}")) do
       click_on 'Edit'
     end
 

--- a/spec/features/admin/admin_dashboard_spec.rb
+++ b/spec/features/admin/admin_dashboard_spec.rb
@@ -1,16 +1,16 @@
-#  
-
 require 'rails_helper'
 
 feature 'An admin visiting the admin dashboard' do
   scenario 'can see all tutorials' do
     admin = create(:admin)
-    create_list(:tutorial, 2)
+    tutorial_1 = create(:tutorial)
+    tutorial_2 = create(:tutorial)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
     visit '/admin/dashboard'
 
-    expect(page).to have_css('.admin-tutorial-card', count: 2)
+    expect(page).to have_css(".admin-tutorial-card-#{tutorial_1.id}")
+    expect(page).to have_css(".admin-tutorial-card-#{tutorial_2.id}")
   end
 end

--- a/spec/features/admin/tutorials/destroy_spec.rb
+++ b/spec/features/admin/tutorials/destroy_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'As an Admin' do
+  before :each do
+    @video = create(:video)
+    @admin = create(:user, role: 1)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    visit admin_dashboard_path
+  end
+
+  it 'When I delete a tutorial the system deletes related videos.' do
+    within ".admin-tutorial-card-#{@video.tutorial.id}" do
+      click_button 'Destroy'
+    end
+
+    expect(current_path).to eq(admin_dashboard_path)
+
+    expect(page).to have_content("#{@video.tutorial.title} has been deleted.")
+
+    expect(Tutorial.all.length).to eq(0)
+    expect(Video.all.length).to eq(0)
+  end
+end


### PR DESCRIPTION
Change links to buttons on Admin Dashboard so they will delete tutorials properly. Added dependent destroy to videos on the tutorial model page so that videos do not persist after tutorial has been deleted.